### PR TITLE
Hackfix mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "quilt-installer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quilt-installer"
 description = "The installer for quilt-loader"
 
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 
 edition = "2021"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 use anyhow::Result;
 use clap::Parser;
 


### PR DESCRIPTION
This is a hackfix that's related to quilt-meta specifying both hashed and intermediary, but quilt-latter silently failing to remap minecraft.

The fix works by simply removing hashed from the launch json.

I've also hidden the console on windows and bumped the version.

This PR exists mainly for documentation, so I will merge it right away.