### PR TITLE
Upstream GitHub Actions including Cargo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         asset_path: ./target/release/quilt-installer.exe
         asset_name: quilt-installer-windows.exe
         asset_content_type: application/octet-stream
-  release-mac:
+  release-macos:
     runs-on: macos-12
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   release-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         asset_name: quilt-installer-linux
         asset_content_type: application/octet-stream
   release-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
         asset_name: quilt-installer-windows.exe
         asset_content_type: application/octet-stream
   release-mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-base64 = "0.13"
-chrono = "0.4"
-clap = { version = "3.2", features = ["derive"] }
-iced = { version = "0.3", default-features = false, features = ["glow", "tokio"] }
-iced_glow = "0.2"
+anyhow = "1.0.65"
+async-trait = "0.1.57"
+base64 = "0.13.0"
+chrono = "0.4.22"
+clap = { version = "4.0.15", features = ["derive"] }
+iced = { version = "0.3.0", default-features = false, features = ["glow", "tokio"] }
+iced_glow = "0.3.0"
 native-dialog = "0.6.3"
-png = "0.17.5"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+png = "0.17.6"
+reqwest = { version = "0.11.12", features = ["blocking", "json"] }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.86"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
This repository contains a now-obsolete version of Ubuntu which was 18.04 LTS which the GitHub team themselves are planning to drop, hence the 22.04 LTS choice - Rest however follows the same path as always.