### PR TITLE
Improve CI for Linux

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   check-linux:
@@ -22,7 +23,7 @@ jobs:
         cargo install cross
         rustup component add rustfmt clippy
     - name: Check
-      run: cross clippy -Dwarnings --target x86_64-unknown-linux-gnu
+      run: cross clippy --target x86_64-unknown-linux-gnu
     - name: Formatting
       run: cross fmt --check
   check-windows:
@@ -37,7 +38,7 @@ jobs:
     - name: Install rustfmt, clippy
       run: rustup component add rustfmt clippy
     - name: Check
-      run: cargo clippy -Dwarnings
+      run: cargo clippy
     - name: Formatting
       run: cargo fmt --check
   check-mac:
@@ -52,6 +53,6 @@ jobs:
     - name: Install rustfmt, clippy
       run: rustup component add rustfmt clippy
     - name: Check
-      run: cargo clippy -Dwarnings
+      run: cargo clippy
     - name: Formatting
       run: cargo fmt --check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release-linux:
+  check-linux:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -17,14 +17,14 @@ jobs:
       run: cargo install cross
     - name: Build
       run: cross check --target x86_64-unknown-linux-gnu
-  release-windows:
+  check-windows:
     runs-on: windows-2019
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build
       run: cargo check
-  release-mac:
+  check-mac:
     runs-on: macos-11
     steps:
     - name: Checkout

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,26 +14,44 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install cross
-      run: cargo install cross
+      run: |
+        cargo install cross
+        rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
-    - name: Build
-      run: cross check --target x86_64-unknown-linux-gnu
+      with:
+        cache-on-failure: true
+    - name: Check
+      run: cross clippy --target x86_64-unknown-linux-gnu
+    - name: Formatting
+      run: cross fmt --check
   check-windows:
     runs-on: windows-2019
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Install rustfmt, clippy
+      run: rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
-    - name: Build
-      run: cargo check
+      with:
+        cache-on-failure: true
+    - name: Check
+      run: cargo clippy
+    - name: Formatting
+      run: cargo fmt --check
   check-mac:
     runs-on: macos-11
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Install rustfmt, clippy
+      run: rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
-    - name: Build
-      run: cargo check
+      with:
+        cache-on-failure: true
+    - name: Check
+      run: cargo clippy
+    - name: Formatting
+      run: cargo fmt --check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install cross
-      run: |
-        cargo install cross
-        rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+    - name: Install cross
+      run: |
+        cargo install cross
+        rustup component add rustfmt clippy
     - name: Check
-      run: cross clippy --target x86_64-unknown-linux-gnu
+      run: cross clippy -Dwarnings --target x86_64-unknown-linux-gnu
     - name: Formatting
       run: cross fmt --check
   check-windows:
@@ -30,14 +30,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install rustfmt, clippy
-      run: rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+    - name: Install rustfmt, clippy
+      run: rustup component add rustfmt clippy
     - name: Check
-      run: cargo clippy
+      run: cargo clippy -Dwarnings
     - name: Formatting
       run: cargo fmt --check
   check-mac:
@@ -45,13 +45,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install rustfmt, clippy
-      run: rustup component add rustfmt clippy
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+    - name: Install rustfmt, clippy
+      run: rustup component add rustfmt clippy
     - name: Check
-      run: cargo clippy
+      run: cargo clippy -Dwarnings
     - name: Formatting
       run: cargo fmt --check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,33 @@
+name: Check
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Install cross
+      run: cargo install cross
+    - name: Build
+      run: cross check --target x86_64-unknown-linux-gnu
+  release-windows:
+    runs-on: windows-2019
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build
+      run: cargo check
+  release-mac:
+    runs-on: macos-11
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build
+      run: cargo check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install cross
       run: cargo install cross
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cross check --target x86_64-unknown-linux-gnu
   check-windows:
@@ -22,6 +24,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo check
   check-mac:
@@ -29,5 +33,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Install cross
       run: cargo install cross
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cross build --target x86_64-unknown-linux-gnu
     - name: Upload
@@ -31,6 +33,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build -r
     - name: Upload
@@ -47,6 +51,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup cache
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build -r
     - name: Upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,14 @@ env:
 
 jobs:
   release-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Install cross
+      run: cargo install cross
     - name: Build
-      run: cargo build -r
+      run: cross build --target x86_64-unknown-linux-gnu
     - name: Upload
       uses: actions/upload-release-asset@v1
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install cross
-      run: cargo install cross
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
+    - name: Install cross
+      run: cargo install cross
     - name: Build
       run: cross build -r --target x86_64-unknown-linux-gnu
     - name: Upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cross build --target x86_64-unknown-linux-gnu
+      run: cross build -r --target x86_64-unknown-linux-gnu
     - name: Upload
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./target/release/quilt-installer
+        asset_path: ./target/x86_64-unknown-linux-gnu/release/quilt-installer
         asset_name: quilt-installer-linux
         asset_content_type: application/octet-stream
   release-windows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1788,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1946,6 +1956,7 @@ dependencies = [
  "iced",
  "iced_glow",
  "native-dialog",
+ "openssl",
  "png",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ png = "0.17.5"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [profile.release]
 strip = true

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+pre-build = [                                  
+    "yum -y install openssl-devel fontconfig-devel"
+] 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,11 @@
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"
+# View the current image version: https://github.com/cross-rs/cross/pkgs/container/x86_64-unknown-linux-gnu
+# Note: For maximal glibc compatibility, the centos version is needed.
+#       To check the glibc version associated with centos, have a look
+#       at the table: https://github.com/cross-rs/cross#supported-targets
+#       Of interest is the x86_64-unknown-linux-gnu:centos row, which
+#       is glibc 2.17 for 0.2.4-centos
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4-centos"
 pre-build = [                                  
     "yum -y install openssl-devel fontconfig-devel"
 ] 


### PR DESCRIPTION
Changing the build command for the linux-release job to use [cross](https://github.com/cross-rs/cross). The linux target gets compiled against `glibc` version `2.17`, the lowest `rust` >= `1.60` itself supports, which should maximize compatibility for many linux distros.

If desired, we can also use cross to setup a build using `musl` instead of `libc`. According to my testing, a binary built with `musl` doesn't work on wayland though, because of [this issue](https://github.com/rust-windowing/winit/issues/1818).

I also implemented a simple `cargo check` workflow for every platform, which is currently triggered by a push.

At the moment, this is an initial draft. Things I would like to improve further are:
 - [x] Caching
 - [x] Run `cargo clippy` on push
 - [x] Run `cargo fmt --check` on push

If this PR looks like it is going in the right direction, I'd like to continue working on above points, otherwise I'm open to change the PR according to your needs.